### PR TITLE
Fix activesupport dependency to support Rails 8

### DIFF
--- a/google-services.gemspec
+++ b/google-services.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dotenv", "~> 3.0"
   
   # Date/Time extensions
-  spec.add_dependency "activesupport", "~> 6.1"
+  spec.add_dependency "activesupport", ">= 6.1"
   
   # CLI
   spec.add_dependency "thor", "~> 1.3"


### PR DESCRIPTION
This PR updates the activesupport dependency from '~> 6.1' to '>= 6.1' to support Rails 8 and newer versions. The current restriction prevents the gem from being used with Rails 7/8 applications. This change maintains backward compatibility while enabling support for newer Rails versions.